### PR TITLE
Fix #1708

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1252,6 +1252,7 @@ def sensors_temperatures():
     basenames.extend(glob.glob('/sys/class/hwmon/hwmon*/device/temp*_*'))
     basenames.extend(glob.glob(
         '/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*'))
+    basenames = list(map(os.path.realpath, basenames))
     basenames = sorted(set([x.split('_')[0] for x in basenames]))
 
     for base in basenames:


### PR DESCRIPTION
Don't duplicate Core temps.

Resolves all symlinks to real files.  The existing lines of code that follow remove duplicates.